### PR TITLE
Feature/clickable references

### DIFF
--- a/internal/ui/curve/curve_info_component.go
+++ b/internal/ui/curve/curve_info_component.go
@@ -3,6 +3,7 @@ package curve
 import (
 	"fan2go-tui/internal/client"
 	"fan2go-tui/internal/ui/txwidget"
+	"strings"
 
 	"github.com/rivo/tview"
 )
@@ -15,12 +16,16 @@ type CurveInfoComponent struct {
 	layout *tview.Flex
 
 	configComponent *txwidget.ConfigInfoComponent
+	onOpenSensor    func(sensorID string)
+	onOpenCurve     func(curveID string)
 }
 
-func NewCurveInfoComponent(application *tview.Application, curve *client.Curve) *CurveInfoComponent {
+func NewCurveInfoComponent(application *tview.Application, curve *client.Curve, onOpenSensor func(sensorID string), onOpenCurve func(curveID string)) *CurveInfoComponent {
 	c := &CurveInfoComponent{
-		application: application,
-		Curve:       curve,
+		application:  application,
+		Curve:        curve,
+		onOpenSensor: onOpenSensor,
+		onOpenCurve:  onOpenCurve,
 	}
 
 	c.layout = c.createLayout()
@@ -32,6 +37,28 @@ func (c *CurveInfoComponent) createLayout() *tview.Flex {
 	layout := tview.NewFlex().SetDirection(tview.FlexRow)
 
 	configComponent := txwidget.NewConfigInfoComponent()
+	configComponent.SetFieldClickablePredicate(func(sectionTitle, label, value string) bool {
+		isSensor := strings.EqualFold(sectionTitle, "Curve") && strings.EqualFold(label, "Sensor") && value != ""
+		isCurveRef := strings.EqualFold(sectionTitle, "Curve") && (strings.EqualFold(label, "Curves") || label == "") && strings.HasPrefix(value, "- ")
+		return isSensor || isCurveRef
+	})
+	configComponent.SetFieldClickHandler(func(sectionTitle, label, value string) {
+		if !strings.EqualFold(sectionTitle, "Curve") {
+			return
+		}
+		if strings.EqualFold(label, "Sensor") {
+			if c.onOpenSensor != nil {
+				c.onOpenSensor(value)
+			}
+			return
+		}
+		if (strings.EqualFold(label, "Curves") || label == "") && strings.HasPrefix(value, "- ") {
+			curveID := strings.TrimSpace(strings.TrimPrefix(value, "- "))
+			if curveID != "" && c.onOpenCurve != nil {
+				c.onOpenCurve(curveID)
+			}
+		}
+	})
 	layout.AddItem(configComponent.GetPrimitive(), 0, 1, false)
 	c.configComponent = configComponent
 

--- a/internal/ui/curve/curve_list_item_component.go
+++ b/internal/ui/curve/curve_list_item_component.go
@@ -18,18 +18,18 @@ type CurveListItemComponent struct {
 	curveGraphComponent *CurveGraphComponent
 }
 
-func NewCurveListItemComponent(application *tview.Application, curve *client.Curve) *CurveListItemComponent {
+func NewCurveListItemComponent(application *tview.Application, curve *client.Curve, onOpenSensor func(sensorID string), onOpenCurve func(curveID string)) *CurveListItemComponent {
 	c := &CurveListItemComponent{
 		application: application,
 		Curve:       curve,
 	}
 
-	c.layout = c.createLayout()
+	c.layout = c.createLayout(onOpenSensor, onOpenCurve)
 
 	return c
 }
 
-func (c *CurveListItemComponent) createLayout() *tview.Flex {
+func (c *CurveListItemComponent) createLayout(onOpenSensor func(sensorID string), onOpenCurve func(curveID string)) *tview.Flex {
 	rootLayout := tview.NewFlex().SetDirection(tview.FlexRow)
 
 	curveColumnLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
@@ -39,7 +39,7 @@ func (c *CurveListItemComponent) createLayout() *tview.Flex {
 	rootLayout.AddItem(curveColumnLayout, 0, 1, true)
 
 	f := c.Curve
-	curveInfoComponent := NewCurveInfoComponent(c.application, f)
+	curveInfoComponent := NewCurveInfoComponent(c.application, f, onOpenSensor, onOpenCurve)
 	c.curveInfoComponent = curveInfoComponent
 	curveInfoComponent.SetCurve(f)
 	layout := curveInfoComponent.GetLayout()

--- a/internal/ui/curve/curves_page.go
+++ b/internal/ui/curve/curves_page.go
@@ -150,3 +150,12 @@ func (c *CurvesPage) Refresh() error {
 func (c *CurvesPage) ScrollToItem() {
 	c.curveList.SelectEntry(c.curveList.GetSelectedItem())
 }
+
+func (c *CurvesPage) SelectCurveByID(curveID string) bool {
+	curveListItem, ok := c.curveListItemComponents[curveID]
+	if !ok {
+		return false
+	}
+	c.curveList.SelectEntry(curveListItem)
+	return true
+}

--- a/internal/ui/curve/curves_page.go
+++ b/internal/ui/curve/curves_page.go
@@ -25,14 +25,18 @@ type CurvesPage struct {
 	curveList *util.ListComponent[CurveListItemComponent]
 
 	curveListItemComponents map[string]*CurveListItemComponent
+	onOpenSensor            func(sensorID string)
+	onOpenCurve             func(curveID string)
 }
 
-func NewCurvesPage(application *tview.Application, client client.Fan2goApiClient) CurvesPage {
+func NewCurvesPage(application *tview.Application, client client.Fan2goApiClient, onOpenSensor func(sensorID string), onOpenCurve func(curveID string)) CurvesPage {
 
 	curvesPage := CurvesPage{
 		application:             application,
 		client:                  client,
 		curveListItemComponents: map[string]*CurveListItemComponent{},
+		onOpenSensor:            onOpenSensor,
+		onOpenCurve:             onOpenCurve,
 	}
 
 	curvesPage.layout = curvesPage.createLayout()
@@ -135,7 +139,7 @@ func (c *CurvesPage) Refresh() error {
 			curveListItemComponent.SetCurve(curve)
 			curveListItemsComponents = append(curveListItemsComponents, curveListItemComponent)
 		} else {
-			curveListItemComponent = NewCurveListItemComponent(c.application, curve)
+			curveListItemComponent = NewCurveListItemComponent(c.application, curve, c.onOpenSensor, c.onOpenCurve)
 			curveListItemComponent.SetCurve(curve)
 			c.curveListItemComponents[cId] = curveListItemComponent
 			curveListItemsComponents = append(curveListItemsComponents, curveListItemComponent)

--- a/internal/ui/fan/fan_info_component.go
+++ b/internal/ui/fan/fan_info_component.go
@@ -3,6 +3,7 @@ package fan
 import (
 	"fan2go-tui/internal/client"
 	"fan2go-tui/internal/ui/txwidget"
+	"strings"
 
 	"github.com/rivo/tview"
 )
@@ -15,12 +16,14 @@ type FanInfoComponent struct {
 	layout *tview.Flex
 
 	configComponent *txwidget.ConfigInfoComponent
+	onOpenCurve     func(curveID string)
 }
 
-func NewFanInfoComponent(application *tview.Application, fan *client.Fan) *FanInfoComponent {
+func NewFanInfoComponent(application *tview.Application, fan *client.Fan, onOpenCurve func(curveID string)) *FanInfoComponent {
 	c := &FanInfoComponent{
 		application: application,
 		Fan:         fan,
+		onOpenCurve: onOpenCurve,
 	}
 
 	c.layout = c.createLayout()
@@ -32,6 +35,14 @@ func (c *FanInfoComponent) createLayout() *tview.Flex {
 	layout := tview.NewFlex().SetDirection(tview.FlexRow)
 
 	configComponent := txwidget.NewConfigInfoComponent()
+	configComponent.SetFieldClickablePredicate(func(sectionTitle, label, value string) bool {
+		return strings.EqualFold(sectionTitle, "General") && strings.EqualFold(label, "Curve") && value != ""
+	})
+	configComponent.SetFieldClickHandler(func(sectionTitle, label, value string) {
+		if c.onOpenCurve != nil && strings.EqualFold(sectionTitle, "General") && strings.EqualFold(label, "Curve") {
+			c.onOpenCurve(value)
+		}
+	})
 	layout.AddItem(configComponent.GetPrimitive(), 0, 1, false)
 	c.configComponent = configComponent
 

--- a/internal/ui/fan/fan_list_item_component.go
+++ b/internal/ui/fan/fan_list_item_component.go
@@ -26,18 +26,18 @@ func hasFanCurveData(fan *client.Fan) bool {
 	return len(*fan.FanCurveData) > 0
 }
 
-func NewFanListItemComponent(application *tview.Application, fan *client.Fan) *FanListItemComponent {
+func NewFanListItemComponent(application *tview.Application, fan *client.Fan, onOpenCurve func(curveID string)) *FanListItemComponent {
 	c := &FanListItemComponent{
 		application: application,
 		Fan:         fan,
 	}
 
-	c.layout = c.createLayout()
+	c.layout = c.createLayout(onOpenCurve)
 
 	return c
 }
 
-func (c *FanListItemComponent) createLayout() *tview.Flex {
+func (c *FanListItemComponent) createLayout(onOpenCurve func(curveID string)) *tview.Flex {
 	rootLayout := tview.NewFlex().SetDirection(tview.FlexRow)
 
 	fanColumnLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
@@ -47,7 +47,7 @@ func (c *FanListItemComponent) createLayout() *tview.Flex {
 	rootLayout.AddItem(fanColumnLayout, 0, 1, true)
 
 	f := c.Fan
-	fanInfoComponent := NewFanInfoComponent(c.application, f)
+	fanInfoComponent := NewFanInfoComponent(c.application, f, onOpenCurve)
 	c.fanInfoComponent = fanInfoComponent
 	fanInfoComponent.SetFan(f)
 	layout := fanInfoComponent.GetLayout()

--- a/internal/ui/fan/fans_page.go
+++ b/internal/ui/fan/fans_page.go
@@ -21,14 +21,16 @@ type FansPage struct {
 	fanList *util.ListComponent[FanListItemComponent]
 
 	fanListItemComponents map[string]*FanListItemComponent
+	onOpenCurve           func(curveID string)
 }
 
-func NewFansPage(application *tview.Application, c client.Fan2goApiClient) FansPage {
+func NewFansPage(application *tview.Application, c client.Fan2goApiClient, onOpenCurve func(curveID string)) FansPage {
 
 	fansPage := FansPage{
 		application:           application,
 		client:                c,
 		fanListItemComponents: map[string]*FanListItemComponent{},
+		onOpenCurve:           onOpenCurve,
 	}
 
 	fansPage.layout = fansPage.createLayout()
@@ -134,7 +136,7 @@ func (c *FansPage) Refresh() error {
 			fanListItemComponent.SetFan(fan)
 			fanListItemsComponents = append(fanListItemsComponents, fanListItemComponent)
 		} else {
-			fanListItemComponent = NewFanListItemComponent(c.application, fan)
+			fanListItemComponent = NewFanListItemComponent(c.application, fan, c.onOpenCurve)
 			c.fanListItemComponents[fId] = fanListItemComponent
 			fanListItemComponent.SetFan(fan)
 			fanListItemsComponents = append(fanListItemsComponents, fanListItemComponent)

--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -79,7 +79,7 @@ func (mainPage *MainPage) createLayout() *tview.Flex {
 	mainPage.mainPagePagerLayout = mainPagePagerLayout
 
 	//graphTestPage := graph_test.NewGraphTestPage(mainPage.application)
-	fansPage := fan.NewFansPage(mainPage.application, mainPage.client)
+	fansPage := fan.NewFansPage(mainPage.application, mainPage.client, mainPage.OpenCurveByID)
 	curvesPage := curve.NewCurvesPage(mainPage.application, mainPage.client)
 	sensorsPage := sensor.NewSensorsPage(mainPage.application, mainPage.client)
 
@@ -177,6 +177,16 @@ func (mainPage *MainPage) NextPage() {
 	currentIndex := slices.Index(keys, mainPage.page)
 	nextIndex := (currentIndex + 1) % len(keys)
 	mainPage.SetPage(keys[nextIndex])
+}
+
+func (mainPage *MainPage) OpenCurveByID(curveID string) {
+	mainPage.SetPage(CurvesPage)
+
+	pagesPage, _ := mainPage.pagesMap.Get(CurvesPage)
+	curveSelectablePage, ok := pagesPage.(interface{ SelectCurveByID(curveID string) bool })
+	if ok {
+		curveSelectablePage.SelectCurveByID(curveID)
+	}
 }
 
 func (mainPage *MainPage) clearStatusMessage() {

--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -80,7 +80,7 @@ func (mainPage *MainPage) createLayout() *tview.Flex {
 
 	//graphTestPage := graph_test.NewGraphTestPage(mainPage.application)
 	fansPage := fan.NewFansPage(mainPage.application, mainPage.client, mainPage.OpenCurveByID)
-	curvesPage := curve.NewCurvesPage(mainPage.application, mainPage.client)
+	curvesPage := curve.NewCurvesPage(mainPage.application, mainPage.client, mainPage.OpenSensorByID, mainPage.OpenCurveByID)
 	sensorsPage := sensor.NewSensorsPage(mainPage.application, mainPage.client)
 
 	//mainPage.AddPage(GraphTestPage, &graphTestPage, true)
@@ -186,6 +186,16 @@ func (mainPage *MainPage) OpenCurveByID(curveID string) {
 	curveSelectablePage, ok := pagesPage.(interface{ SelectCurveByID(curveID string) bool })
 	if ok {
 		curveSelectablePage.SelectCurveByID(curveID)
+	}
+}
+
+func (mainPage *MainPage) OpenSensorByID(sensorID string) {
+	mainPage.SetPage(SensorsPage)
+
+	pagesPage, _ := mainPage.pagesMap.Get(SensorsPage)
+	sensorSelectablePage, ok := pagesPage.(interface{ SelectSensorByID(sensorID string) bool })
+	if ok {
+		sensorSelectablePage.SelectSensorByID(sensorID)
 	}
 }
 

--- a/internal/ui/sensor/sensors_page.go
+++ b/internal/ui/sensor/sensors_page.go
@@ -149,3 +149,12 @@ func (c *SensorsPage) Refresh() error {
 func (c *SensorsPage) ScrollToItem() {
 	c.sensorList.SelectEntry(c.sensorList.GetSelectedItem())
 }
+
+func (c *SensorsPage) SelectSensorByID(sensorID string) bool {
+	sensorListItem, ok := c.sensorListItemComponents[sensorID]
+	if !ok {
+		return false
+	}
+	c.sensorList.SelectEntry(sensorListItem)
+	return true
+}

--- a/internal/ui/txwidget/config_info_component.go
+++ b/internal/ui/txwidget/config_info_component.go
@@ -34,16 +34,44 @@ type ConfigInfoSection struct {
 
 type ConfigInfoComponent struct {
 	layout *tview.TextView
+
+	isFieldClickable func(sectionTitle, label, value string) bool
+	onFieldClick     func(sectionTitle, label, value string)
+	fieldClickByID   map[string]clickableConfigField
+}
+
+type clickableConfigField struct {
+	sectionTitle string
+	field        ConfigInfoField
 }
 
 func NewConfigInfoComponent() *ConfigInfoComponent {
 	textView := tview.NewTextView().
 		SetDynamicColors(true).
 		SetWrap(false).
-		SetScrollable(true)
+		SetScrollable(true).
+		SetRegions(true)
 	textView.SetBorderPadding(0, 0, 0, 0)
 
-	c := &ConfigInfoComponent{layout: textView}
+	c := &ConfigInfoComponent{
+		layout: textView,
+		isFieldClickable: func(sectionTitle, label, value string) bool {
+			return false
+		},
+		onFieldClick:   func(sectionTitle, label, value string) {},
+		fieldClickByID: map[string]clickableConfigField{},
+	}
+	textView.SetHighlightedFunc(func(added, _, _ []string) {
+		if len(added) == 0 {
+			return
+		}
+		clickableField, ok := c.fieldClickByID[added[0]]
+		if !ok {
+			return
+		}
+		c.onFieldClick(clickableField.sectionTitle, clickableField.field.Label, clickableField.field.Value)
+		c.layout.Highlight()
+	})
 	textView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
 		case tcell.KeyRight:
@@ -72,11 +100,14 @@ func (w *ConfigInfoComponent) GetPrimitive() tview.Primitive {
 }
 
 func (w *ConfigInfoComponent) SetSections(sections []ConfigInfoSection) {
+	w.fieldClickByID = map[string]clickableConfigField{}
+
 	type renderSection struct {
-		headerTitle string
-		typeValue   string
-		accent      ConfigInfoAccent
-		fields      []ConfigInfoField
+		headerTitle  string
+		typeValue    string
+		accent       ConfigInfoAccent
+		sectionTitle string
+		fields       []ConfigInfoField
 	}
 
 	renderSections := make([]renderSection, 0, len(sections))
@@ -94,10 +125,11 @@ func (w *ConfigInfoComponent) SetSections(sections []ConfigInfoSection) {
 			}
 		}
 		renderSections = append(renderSections, renderSection{
-			headerTitle: headerTitle,
-			typeValue:   typeValue,
-			accent:      section.Accent,
-			fields:      fields,
+			headerTitle:  headerTitle,
+			typeValue:    typeValue,
+			accent:       section.Accent,
+			sectionTitle: section.Title,
+			fields:       fields,
 		})
 	}
 
@@ -113,12 +145,21 @@ func (w *ConfigInfoComponent) SetSections(sections []ConfigInfoSection) {
 		for _, field := range section.fields {
 			valueColor := resolveValueColor(field.Label, field.Value, section.typeValue)
 			valueColorTag := colorTag(valueColor)
+			valueText := tview.Escape(field.Value)
+			if w.isFieldClickable(section.sectionTitle, field.Label, field.Value) {
+				regionID := fmt.Sprintf("field-%d", len(w.fieldClickByID))
+				w.fieldClickByID[regionID] = clickableConfigField{
+					sectionTitle: section.sectionTitle,
+					field:        field,
+				}
+				valueText = fmt.Sprintf("[\"%s\"]%s[\"\"]", regionID, valueText)
+			}
 			out.WriteString(fmt.Sprintf("%s%-*s[-] %s%s[-]\n",
 				keyColorTag,
 				maxKeyLen,
 				tview.Escape(field.Label),
 				valueColorTag,
-				tview.Escape(field.Value),
+				valueText,
 			))
 		}
 	}
@@ -145,6 +186,24 @@ func (w *ConfigInfoComponent) ScrollHorizontal(delta int) {
 		nextCol = 0
 	}
 	w.layout.ScrollTo(rowOffset, nextCol)
+}
+
+func (w *ConfigInfoComponent) SetFieldClickablePredicate(predicate func(sectionTitle, label, value string) bool) {
+	if predicate == nil {
+		w.isFieldClickable = func(sectionTitle, label, value string) bool {
+			return false
+		}
+		return
+	}
+	w.isFieldClickable = predicate
+}
+
+func (w *ConfigInfoComponent) SetFieldClickHandler(handler func(sectionTitle, label, value string)) {
+	if handler == nil {
+		w.onFieldClick = func(sectionTitle, label, value string) {}
+		return
+	}
+	w.onFieldClick = handler
 }
 
 func colorTag(color tcell.Color) string {


### PR DESCRIPTION
This pull request introduces interactive navigation between related entities (Fans, Curves, and Sensors) in the TUI by making fields in the configuration info components clickable. When users click on certain fields (such as a curve reference in a fan, or a sensor reference in a curve), the UI will automatically switch to the relevant page and highlight the selected item. This is achieved by adding click handlers and predicates to the `ConfigInfoComponent`, and by wiring up navigation callbacks throughout the UI components and pages.

Key changes include:

**Interactive Field Clicks and Navigation:**
- Added support for marking specific fields in `ConfigInfoComponent` as clickable, including predicates to determine clickability and handlers to process clicks. When clicked, these fields trigger navigation callbacks to open the corresponding Curve or Sensor. [[1]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R37-R74) [[2]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R148-R162) [[3]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R191-R208)
- Implemented logic in `CurveInfoComponent` and `FanInfoComponent` to specify which fields are clickable (e.g., "Sensor" in a Curve, "Curve" in a Fan) and to handle navigation when these fields are clicked. [[1]](diffhunk://#diff-71cfe79e6c3af928b018797ac19bcd1771990bdcfb5d1e55e48161129972f78fR40-R61) [[2]](diffhunk://#diff-562ce5baf100dcb5aeb01609189b4aa9b46b7504e5ce6b85ed9846680d6fe894R38-R45)

**Callback Propagation and Page Selection:**
- Updated constructors and layout methods for Fan and Curve list/item components and pages to accept and propagate navigation callbacks (`onOpenCurve`, `onOpenSensor`). [[1]](diffhunk://#diff-71cfe79e6c3af928b018797ac19bcd1771990bdcfb5d1e55e48161129972f78fR19-R28) [[2]](diffhunk://#diff-430419f1abb7ea7f957fc55e3b853c3a105149a6a2c176483ccda1c5aa1f5e34L21-R32) [[3]](diffhunk://#diff-bfebc1bb6aca851c95624d55e73ddea1bd2629c39d415a8acb01457f78444a62R24-R33) [[4]](diffhunk://#diff-d5d5a2b714ce67430ae229969c217c14fed5f1305361017b0b1f42675e7222c9R28-R39) [[5]](diffhunk://#diff-562ce5baf100dcb5aeb01609189b4aa9b46b7504e5ce6b85ed9846680d6fe894R19-R26) [[6]](diffhunk://#diff-3454b64114071bb32c8f174a1e5a079b7a8c8ba5ac24c9065aa6025ec13666f5L29-R40)
- Added methods to CurvesPage and SensorsPage to select and highlight an item by ID, enabling direct navigation to specific items from other pages. [[1]](diffhunk://#diff-d5d5a2b714ce67430ae229969c217c14fed5f1305361017b0b1f42675e7222c9R157-R165) [[2]](diffhunk://#diff-95c9c819ab4474ba2e672e0c66c776e8db9eed02c522f76436bcf9531ab4b0feR152-R160)

**Main Page Integration:**
- Integrated new navigation functions (`OpenCurveByID`, `OpenSensorByID`) into the main page, allowing page switching and item selection in response to field clicks. [[1]](diffhunk://#diff-7e68e25f907fe83d4294ee6692e30464a4101bbe5fe7735f9223f6e1d77c02adL82-R83) [[2]](diffhunk://#diff-7e68e25f907fe83d4294ee6692e30464a4101bbe5fe7735f9223f6e1d77c02adR182-R201)

These changes collectively provide a more intuitive and interconnected user experience, allowing users to quickly jump between related entities in the TUI with a click.

**References:**  
[[1]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R37-R74) [[2]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R148-R162) [[3]](diffhunk://#diff-d6215df95b83ad279d309829b446978ed7803ffc532633f5cb532c2a7104d250R191-R208) [[4]](diffhunk://#diff-71cfe79e6c3af928b018797ac19bcd1771990bdcfb5d1e55e48161129972f78fR40-R61) [[5]](diffhunk://#diff-562ce5baf100dcb5aeb01609189b4aa9b46b7504e5ce6b85ed9846680d6fe894R38-R45) [[6]](diffhunk://#diff-71cfe79e6c3af928b018797ac19bcd1771990bdcfb5d1e55e48161129972f78fR19-R28) [[7]](diffhunk://#diff-430419f1abb7ea7f957fc55e3b853c3a105149a6a2c176483ccda1c5aa1f5e34L21-R32) [[8]](diffhunk://#diff-bfebc1bb6aca851c95624d55e73ddea1bd2629c39d415a8acb01457f78444a62R24-R33) [[9]](diffhunk://#diff-d5d5a2b714ce67430ae229969c217c14fed5f1305361017b0b1f42675e7222c9R28-R39) [[10]](diffhunk://#diff-562ce5baf100dcb5aeb01609189b4aa9b46b7504e5ce6b85ed9846680d6fe894R19-R26) [[11]](diffhunk://#diff-3454b64114071bb32c8f174a1e5a079b7a8c8ba5ac24c9065aa6025ec13666f5L29-R40) [[12]](diffhunk://#diff-d5d5a2b714ce67430ae229969c217c14fed5f1305361017b0b1f42675e7222c9R157-R165) [[13]](diffhunk://#diff-95c9c819ab4474ba2e672e0c66c776e8db9eed02c522f76436bcf9531ab4b0feR152-R160) [[14]](diffhunk://#diff-7e68e25f907fe83d4294ee6692e30464a4101bbe5fe7735f9223f6e1d77c02adL82-R83) [[15]](diffhunk://#diff-7e68e25f907fe83d4294ee6692e30464a4101bbe5fe7735f9223f6e1d77c02adR182-R201)